### PR TITLE
Resolve hugepage interaction issues with vpp and KVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,10 @@ dkms.conf
 .env
 
 # Terraform
-*tfstate
+*tfstate*
 *tfstate.backup
 *.lock.info
 
 # Ansible
 *retry
-*inventory
+*inventory*

--- a/comparison/ansible/roles/grub_openstack/tasks/main.yml
+++ b/comparison/ansible/roles/grub_openstack/tasks/main.yml
@@ -3,7 +3,7 @@
   lineinfile: 
     dest: /etc/default/grub 
     regexp: ^GRUB_CMDLINE_LINUX= 
-    line: GRUB_CMDLINE_LINUX="console=tty0 console=ttyS1,115200n8 biosdevname=0 rd.auto rd.auto=1 net.ifnames=1 hugepagesz=2M hugepages=4096 transparent_hugepages=never nmi_watchdog=0 audit=0 nosoftlockup processor.max_cstate=1 intel_idle.max_cstate=1 hpet=disable tsc=reliable mce=off numa_balancing=disable intel_pstate=disable intel_iommu=on iommu=pt"
+    line: GRUB_CMDLINE_LINUX="console=tty0 console=ttyS1,115200n8 biosdevname=0 rd.auto rd.auto=1 net.ifnames=1 hugepagesz=2MB hugepages=32768 transparent_hugepages=never nmi_watchdog=0 audit=0 nosoftlockup processor.max_cstate=1 intel_idle.max_cstate=1 hpet=disable tsc=reliable mce=off numa_balancing=disable intel_pstate=disable intel_iommu=on iommu=pt"
   register: grub_update
 
 - name: Update Grub

--- a/comparison/ansible/roles/openstack_scripts/templates/create_flavor.sh
+++ b/comparison/ansible/roles/openstack_scripts/templates/create_flavor.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 source ~/openrc
-if [[ ! $(openstack flavor list | grep hp. | wc -l) -ge 2 ]]; then
-  openstack flavor create --id 1 --ram 16384 --disk 10 hp.small
-  openstack flavor create --id 2 --ram 32768 --disk 10 hp.large
+if [[ ! $(openstack flavor list | grep c0. | wc -l) -ge 2 ]]; then
+  openstack flavor create --id 1 --ram 8192 --disk 10 --property hw:numa_nodes=1 --property hw:mem_page_size=2048 --property hw:numa_cpus.0=0 --property hw:numa_mem.0=8192 c0.small
+  openstack flavor create --id 2 --ram 8192 --disk 10 --property hw:numa_nodes=1 --property hw:mem_page_size=2048 --property hw:numa_cpus.1=0 --property hw:numa_mem.1=8192 c1.small
+
+  openstack flavor create --id 4 --ram 16384 --vcpus 2 --disk 10 --property hw:numa_nodes=2 --property hw:mem_page_size=2048 --property hw:numa_cpus.0=0,1 --property hw:numa_mem.0=16384 c0.med
+  openstack flavor create --id 5 --ram 16384 --vcpus 2 --disk 10 --property hw:numa_nodes=2 --property hw:mem_page_size=2048 --property hw:numa_cpus.1=0,1 --property hw:numa_mem.1=16384 c1.med
 fi
-# --property hw:numa_nodes=1 --property hw:mem_page_size=2048

--- a/comparison/ansible/roles/openstack_scripts/templates/create_instance.sh
+++ b/comparison/ansible/roles/openstack_scripts/templates/create_instance.sh
@@ -8,7 +8,9 @@ ubuntu
 EOL
 EOF
 
-network=`openstack network list | awk '/vlan/ {print $4}'`
-openstack  server create test${1} --flavor 1 --image xenial --nic net-id=${network} --property hw:mem_page_size=2048 --config-drive True --user-data /tmp/test${1}.cfg
+FLAVOR=${2:-c0.small}
 
-#--property hw:numa_nodes=0
+network=`openstack network list | awk '/vlan/ {print $4}'`
+openstack  server create test${1} --flavor ${FLAVOR} --image xenial --nic net-id=${network} --config-drive True --user-data /tmp/test${1}.cfg
+
+

--- a/comparison/ansible/roles/openstack_scripts/templates/create_security_groups.sh
+++ b/comparison/ansible/roles/openstack_scripts/templates/create_security_groups.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ~/openrc
 
 admin_project=$(openstack project list | awk '/admin/ {print $2}')
 admin_default=$(openstack security group list | grep $admin_project | awk '{print $2}')

--- a/comparison/ansible/roles/openstack_scripts/templates/create_vlans.sh
+++ b/comparison/ansible/roles/openstack_scripts/templates/create_vlans.sh
@@ -7,5 +7,5 @@ fi
 source ~/openrc
 openstack network create --provider-segment ${1} --provider-network-type vlan --provider-physical-network provider vlan${1}
 (( vlan_subnet = $1 - 1000 ))
-openstack subnet create --network vlan${1} --subnet-range 10.${vlan_subnet}.0.0/24  --gateway none subnet${1}
+openstack subnet create --network vlan${1} --subnet-range 10.${vlan_subnet}.0.0/24 --no-dhcp --gateway none subnet${1}
 

--- a/comparison/ansible/roles/openstack_scripts/templates/etcdctl_set.sh
+++ b/comparison/ansible/roles/openstack_scripts/templates/etcdctl_set.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "export ETCDCTL_ENDPOINTS=http://$(hostname -I):2379"
+echo "etcdctl cluster-health"

--- a/comparison/ansible/roles/vpp_openstack/handlers/main.yml
+++ b/comparison/ansible/roles/vpp_openstack/handlers/main.yml
@@ -28,7 +28,7 @@
   service:
     name: apache2
     state: restarted
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and host_0_address == inventory_hostname
 
 - name: Restart vpp-agent
   service:

--- a/comparison/ansible/roles/vpp_openstack/tasks/main.yml
+++ b/comparison/ansible/roles/vpp_openstack/tasks/main.yml
@@ -18,7 +18,7 @@
     mode: 0644
   when: ansible_os_family == 'Debian'
 
-- name: add missing params to nova.conf
+- name: add missing network params to nova.conf
   ini_file:
     dest: /etc/nova/nova.conf
     section: DEFAULT
@@ -29,6 +29,20 @@
     - {option: 'vif_plugging_is_fatal', value: 'True' }
     - {option: 'use_neutron', value: 'True' }
     - {option: 'firewall_driver', value: 'nova.virt.firewall.NoopFirewallDriver' }
+  notify:
+  - Restart nova-compute
+    
+- name: add missing scheduler params to nova.conf
+  ini_file:
+    dest: /etc/nova/nova.conf
+    section: scheduler
+    option: "{{item.option}}"
+    value: "{{item.value}}"
+  with_items:
+    - {option: 'scheduler_driver_task_period', value: '60' }
+    - {option: 'scheduler_driver', value: 'nova.scheduler.filter_scheduler.FilterScheduler' }
+    - {option: 'schedulr_available_filters', value: 'nova.scheduler.filters.all_filters' }
+    - {option: 'scheduler_default_filters', value: 'RetryFilter, AvailabilityZoneFilter, RamFilter, DiskFilter, ComputeFilter, ComputeCapabilitiesFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter, NUMATopologyFilter' }
   notify:
   - Restart nova-compute
     
@@ -139,7 +153,7 @@
   register: hugepages
 
 - name: reload vpp hugepage support
-  command: sysctl -p /etc/sysctl.d/80-vpp.conf
+  command: sysctl --system
   when: hugepages.changed
   notify:
   - Restart apache

--- a/comparison/ansible/roles/vpp_openstack/templates/80-vpp.conf
+++ b/comparison/ansible/roles/vpp_openstack/templates/80-vpp.conf
@@ -1,8 +1,8 @@
 # Number of 2MB hugepages desired
-vm.nr_hugepages=4096
+vm.nr_hugepages=32768
 
 # Must be greater than or equal to (2 * vm.nr_hugepages).
-vm.max_map_count=9216
+vm.max_map_count=67584
 
 # All groups allowed to access hugepages
 vm.hugetlb_shm_group=0
@@ -12,4 +12,4 @@ vm.hugetlb_shm_group=0
 # If the existing kernel.shmmax setting  (cat /sys/proc/kernel/shmmax)
 # is greater than the calculated TotalHugepageSize then set this parameter
 # to current shmmax value.
-kernel.shmmax=8589934592
+kernel.shmmax=68719476736

--- a/comparison/ansible/roles/vpp_openstack/templates/vpp-agent-debian.service
+++ b/comparison/ansible/roles/vpp_openstack/templates/vpp-agent-debian.service
@@ -1,6 +1,6 @@
 [Unit]
 Description = OpenStack VPP Agent
-After=syslog.target network.target neutron.server
+After=syslog.target network.target
 
 [Service]
 ExecReload = /bin/kill -HUP $MAINPID

--- a/comparison/ansible/roles/vpp_openstack/templates/vpp-agent-redhat.service
+++ b/comparison/ansible/roles/vpp_openstack/templates/vpp-agent-redhat.service
@@ -1,6 +1,6 @@
 [Unit]
 Description = OpenStack VPP Agent
-After=syslog.target network.target neutron.server
+After=syslog.target network.target
 
 [Service]
 ExecReload = /bin/kill -HUP $MAINPID

--- a/comparison/ansible/roles/vpp_src_install/defaults/main.yml
+++ b/comparison/ansible/roles/vpp_src_install/defaults/main.yml
@@ -1,3 +1,4 @@
 mlnx_ver: 4.4-2.0.7.0
 arch: ubuntu16.04-x86_64
 vpp_ver: 1807
+vpp_commit: 909ba93249532a35ce53e578cf622c8069045f84

--- a/comparison/ansible/roles/vpp_src_install/tasks/main.yml
+++ b/comparison/ansible/roles/vpp_src_install/tasks/main.yml
@@ -7,7 +7,7 @@
   git:
     repo: 'https://gerrit.fd.io/r/vpp'
     dest: /srv/vpp
-    version: origin/stable/{{vpp_ver}}
+    version: "{{vpp_commit}}"
     update: no
 
 - name: Set VPP DPDK mlx5 PMD use

--- a/comparison/ansible/roles/vpp_src_install/templates/startup.conf
+++ b/comparison/ansible/roles/vpp_src_install/templates/startup.conf
@@ -15,9 +15,13 @@ api-segment {
 }
 
 cpu {
-
+  main-core 1
+  heapsize {
+   2G
+  }
 }
 
 dpdk {
-  socket-mem 1024,2048
+  huge-dir /dev/hugepages
+  socket-mem 2048,2048
 }


### PR DESCRIPTION
Fixes Issue #101

Seems that the principal interaction failure was due to a major
mismatch between VPP's hugepage config (or lack thereof), and
a hugepage config that also works with OpenStack.  Once enough
pages were available to VPP (more than 512) and once the now
default OS based hugepage directory (/dev/hugepages) was set
it was possible to launch VMs and have Neutron properly configure
the environment.

Additional errors that caused issues:
VPP and Neutron DHCP do not play nicely, or at least not with this
specific cnfiguration, and the network script that helps set up a
test network needed the --no-dhcp option in addition to the current
--gateway none confguration.

The neutron flavor script needed to include a hw:numa_nodes=1 or
greater parameter or the cpu and memory specific parameters are
ignored. It may be that these are no longer necessary with the
hugepage config set on VPP, but this does effectively pin
the VM to one NUMA node or the other. It's not clear that the
config does a 1 to 1 mapping given the OpenStack documentation
but it does appear to configure a libvirt cpu pinning operation
with this specific set of flavor options.

VPP branch from git 'stable/18.07' still has active commits, so
the version was locked to a specific git commit id to ensure
repeatable results. The above mentioned DHCP issue was the
apparent cause of inconsistences rather than the updated
commit to VPP, but at this point, we're commit locked.

VPP-agent (the neutron-agent for host config) was not starting
due to a reliance on the neutron-server service being started
but the neutron-servrer service doesn't exist on the compute
nodes, where the agent normally needs to run (router/dhcp configs
may still require the agent on the OpenStack control nodes
as well).

VPP Startup.conf was simplified but the hugepage parameter
(which doesn't exist in the documentation) was added
to point to the proper hugepages directory.

Grub for openstack was also updated to ensure that there
are enough hugepages for a reasonable number of VMs per host
at least for testing purposes.